### PR TITLE
Add detailed examples for props, state, effects, and a Todo mini project

### DIFF
--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,15 +1,21 @@
 /**
  * App.jsx
  * ----------
- * This file defines our first React component.
- * Components are like LEGO blocks: small, reusable pieces that build the UI.
- * Instead of manipulating the DOM manually, React renders this component
- * using a virtual DOM and updates only what's necessary.
+ * Root component showcasing core React concepts:
+ *  - Passing data with props
+ *  - Managing state with `useState`
+ *  - Handling side effects with `useEffect`
+ *  - A mini Todo project combining these ideas
  */
+
+import Greeting from './components/Greeting.jsx'
+import Counter from './components/Counter.jsx'
+import Timer from './components/Timer.jsx'
+import TodoApp from './components/TodoApp.jsx'
 
 function App() {
   // JavaScript can be embedded directly inside JSX using curly braces
-  const name = "Harsh"
+  const name = 'Harsh'
 
   return (
     <div>
@@ -17,6 +23,31 @@ function App() {
       <h1>Hello React! 🚀</h1>
       {/* Demonstrating dynamic content with a JavaScript variable */}
       <h2>Hello {name}</h2>
+
+      {/* ----- Props Example ----- */}
+      <section>
+        <h3>Props</h3>
+        {/* Passing data to a child component like a read-only tiffin box */}
+        <Greeting name="Students" />
+      </section>
+
+      {/* ----- useState Example ----- */}
+      <section>
+        <h3>useState</h3>
+        <Counter />
+      </section>
+
+      {/* ----- useEffect Example ----- */}
+      <section>
+        <h3>useEffect</h3>
+        <Timer />
+      </section>
+
+      {/* ----- Mini Project: Todo App ----- */}
+      <section>
+        <h3>Todo App</h3>
+        <TodoApp />
+      </section>
     </div>
   )
 }

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,3 +1,9 @@
+import Greeting from "./components/Greeting.jsx";
+import Counter from "./components/Counter.jsx";
+import Timer from "./components/Timer.jsx";
+import TodoApp from "./components/TodoApp.jsx";
+import "./App.css";
+
 /**
  * App.jsx
  * ----------
@@ -7,15 +13,9 @@
  *  - Handling side effects with `useEffect`
  *  - A mini Todo project combining these ideas
  */
-
-import Greeting from './components/Greeting.jsx'
-import Counter from './components/Counter.jsx'
-import Timer from './components/Timer.jsx'
-import TodoApp from './components/TodoApp.jsx'
-
 function App() {
   // JavaScript can be embedded directly inside JSX using curly braces
-  const name = 'Harsh'
+  const name = "Harsh";
 
   return (
     <div>
@@ -49,7 +49,7 @@ function App() {
         <TodoApp />
       </section>
     </div>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/my-app/src/components/Counter.jsx
+++ b/my-app/src/components/Counter.jsx
@@ -1,0 +1,27 @@
+/**
+ * Counter.jsx
+ * ------------
+ * Demonstrates component state using the `useState` hook.
+ *
+ * State is like a component's private memory. Calling the updater
+ * function triggers React to re-render with the new state value.
+ */
+
+import { useState } from 'react'
+
+function Counter() {
+  // `count` stores the current number of clicks
+  // `setCount` updates `count` and causes a re-render
+  const [count, setCount] = useState(0)
+
+  return (
+    <>
+      {/* Display how many times the button has been clicked */}
+      <p>You clicked {count} times</p>
+      {/* Update state on click */}
+      <button onClick={() => setCount(count + 1)}>Click me</button>
+    </>
+  )
+}
+
+export default Counter

--- a/my-app/src/components/Greeting.jsx
+++ b/my-app/src/components/Greeting.jsx
@@ -1,0 +1,19 @@
+/**
+ * Greeting.jsx
+ * -------------
+ * Demonstrates how to pass data into a component using props.
+ *
+ * Think of props like a tiffin box 🍱: a parent component packs data
+ * and hands it to the child component. The child can only read what it
+ * receives; props are read-only.
+ */
+
+// `name` is received from the parent component via props
+function Greeting({ name }) {
+  return (
+    // Display the name inside a heading
+    <h2>Hello {name}</h2>
+  )
+}
+
+export default Greeting

--- a/my-app/src/components/Timer.jsx
+++ b/my-app/src/components/Timer.jsx
@@ -1,0 +1,26 @@
+/**
+ * Timer.jsx
+ * ----------
+ * Shows how to perform side effects with `useEffect`.
+ *
+ * Side effects include tasks like setting up timers, fetching data,
+ * or interacting with localStorage. Always clean up effects to avoid
+ * memory leaks.
+ */
+
+import { useState, useEffect } from 'react'
+
+function Timer() {
+  const [seconds, setSeconds] = useState(0)
+
+  useEffect(() => {
+    // Increment the timer every second
+    const timer = setInterval(() => setSeconds(s => s + 1), 1000)
+    // Cleanup: stop the timer when the component unmounts
+    return () => clearInterval(timer)
+  }, []) // Empty dependency array -> run once on mount
+
+  return <p>Timer: {seconds}s</p>
+}
+
+export default Timer

--- a/my-app/src/components/TodoApp.jsx
+++ b/my-app/src/components/TodoApp.jsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+
 /**
  * TodoApp.jsx
  * ------------
@@ -8,47 +10,44 @@
  *  - Delete tasks
  *  - Persist tasks in `localStorage`
  */
-
-import { useState, useEffect } from 'react'
-
 function TodoApp() {
-  const [tasks, setTasks] = useState([])
-  const [input, setInput] = useState('')
+  const [tasks, setTasks] = useState([]);
+  const [input, setInput] = useState("");
 
   // Load saved tasks from localStorage when the component mounts
   useEffect(() => {
-    const saved = JSON.parse(localStorage.getItem('tasks')) || []
-    setTasks(saved)
-  }, [])
+    const saved = JSON.parse(localStorage.getItem("tasks")) || [];
+    setTasks(saved);
+  }, []);
 
   // Save tasks to localStorage whenever the task list changes
   useEffect(() => {
-    localStorage.setItem('tasks', JSON.stringify(tasks))
-  }, [tasks])
+    localStorage.setItem("tasks", JSON.stringify(tasks));
+  }, [tasks]);
 
   const addTask = () => {
-    if (!input.trim()) return // prevent empty tasks
-    setTasks([...tasks, input])
-    setInput('')
-  }
+    if (!input.trim()) return; // prevent empty tasks
+    setTasks([...tasks, input]);
+    setInput("");
+  };
 
-  const deleteTask = index => {
-    setTasks(tasks.filter((_, i) => i !== index))
-  }
+  const deleteTask = (index) => {
+    setTasks(tasks.filter((_, i) => i !== index));
+  };
 
   return (
     <div>
       <h2>Todo List</h2>
       <input
         value={input}
-        onChange={e => setInput(e.target.value)}
+        onChange={(e) => setInput(e.target.value)}
         placeholder="Enter a task"
       />
       <button onClick={addTask}>Add</button>
       <ul>
         {tasks.map((task, i) => (
           <li key={i}>
-            {task}{' '}
+            {task}{" "}
             <button aria-label={`Delete ${task}`} onClick={() => deleteTask(i)}>
               ❌
             </button>
@@ -56,7 +55,7 @@ function TodoApp() {
         ))}
       </ul>
     </div>
-  )
+  );
 }
 
-export default TodoApp
+export default TodoApp;

--- a/my-app/src/components/TodoApp.jsx
+++ b/my-app/src/components/TodoApp.jsx
@@ -1,0 +1,62 @@
+/**
+ * TodoApp.jsx
+ * ------------
+ * Mini project tying together `useState` and `useEffect`.
+ *
+ * Features:
+ *  - Add tasks
+ *  - Delete tasks
+ *  - Persist tasks in `localStorage`
+ */
+
+import { useState, useEffect } from 'react'
+
+function TodoApp() {
+  const [tasks, setTasks] = useState([])
+  const [input, setInput] = useState('')
+
+  // Load saved tasks from localStorage when the component mounts
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem('tasks')) || []
+    setTasks(saved)
+  }, [])
+
+  // Save tasks to localStorage whenever the task list changes
+  useEffect(() => {
+    localStorage.setItem('tasks', JSON.stringify(tasks))
+  }, [tasks])
+
+  const addTask = () => {
+    if (!input.trim()) return // prevent empty tasks
+    setTasks([...tasks, input])
+    setInput('')
+  }
+
+  const deleteTask = index => {
+    setTasks(tasks.filter((_, i) => i !== index))
+  }
+
+  return (
+    <div>
+      <h2>Todo List</h2>
+      <input
+        value={input}
+        onChange={e => setInput(e.target.value)}
+        placeholder="Enter a task"
+      />
+      <button onClick={addTask}>Add</button>
+      <ul>
+        {tasks.map((task, i) => (
+          <li key={i}>
+            {task}{' '}
+            <button aria-label={`Delete ${task}`} onClick={() => deleteTask(i)}>
+              ❌
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default TodoApp


### PR DESCRIPTION
## Summary
- Add `Greeting`, `Counter`, `Timer`, and `TodoApp` components with comments explaining props, state, and effects
- Extend `App` to render the new examples and mini project

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ade3e1140c8321a7556def15f3598c