### PR TITLE
feat: add React mini-cart with routing and context

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1370,7 +1372,7 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1603,6 +1605,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1622,7 +1633,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2478,6 +2489,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2543,6 +2592,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2793,6 +2848,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,24 +1,56 @@
-/**
- * App.jsx
- * ----------
- * This file defines our first React component.
- * Components are like LEGO blocks: small, reusable pieces that build the UI.
- * Instead of manipulating the DOM manually, React renders this component
- * using a virtual DOM and updates only what's necessary.
- */
+import { Link, Route, Routes } from 'react-router-dom'
+import ProductsPage from './pages/ProductsPage'
+import CartPage from './pages/CartPage'
+import Button from './components/atoms/Button'
+import { useThemeStore } from './store/useThemeStore'
 
-function App() {
-  // JavaScript can be embedded directly inside JSX using curly braces
-  const name = "Harsh"
+/**
+ * App component
+ * -------------
+ * Sets up routing and demonstrates Zustand for theme state.
+ */
+export default function App() {
+  const { theme, toggle } = useThemeStore()
 
   return (
-    <div>
-      {/* Simple heading rendered by the component */}
-      <h1>Hello React! 🚀</h1>
-      {/* Demonstrating dynamic content with a JavaScript variable */}
-      <h2>Hello {name}</h2>
+    <div
+      style={{
+        fontFamily: 'sans-serif',
+        background: theme === 'light' ? '#fff' : '#202124',
+        color: theme === 'light' ? '#202124' : '#fff',
+        minHeight: '100vh',
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: 16,
+          background: '#4285F4',
+          color: '#fff',
+        }}
+      >
+        <nav style={{ display: 'flex', gap: 16 }}>
+          {/* React Router links */}
+          <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>
+            Products
+          </Link>
+          <Link to="/cart" style={{ color: '#fff', textDecoration: 'none' }}>
+            Cart
+          </Link>
+        </nav>
+        {/* Using Zustand global state */}
+        <Button onClick={toggle} style={{ background: '#0F9D58' }}>
+          Toggle {theme === 'light' ? 'Dark' : 'Light'}
+        </Button>
+      </header>
+      <main style={{ padding: 16 }}>
+        <Routes>
+          <Route path="/" element={<ProductsPage />} />
+          <Route path="/cart" element={<CartPage />} />
+        </Routes>
+      </main>
     </div>
   )
 }
-
-export default App

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,8 +1,9 @@
-import { Link, Route, Routes } from 'react-router-dom'
-import ProductsPage from './pages/ProductsPage'
-import CartPage from './pages/CartPage'
-import Button from './components/atoms/Button'
-import { useThemeStore } from './store/useThemeStore'
+import { Link, Route, Routes } from "react-router-dom";
+import ProductsPage from "./pages/ProductsPage";
+import CartPage from "./pages/CartPage";
+import Button from "./components/atoms/Button";
+import { useThemeStore } from "./store/useThemeStore";
+import "./App.css";
 
 /**
  * App component
@@ -10,39 +11,39 @@ import { useThemeStore } from './store/useThemeStore'
  * Sets up routing and demonstrates Zustand for theme state.
  */
 export default function App() {
-  const { theme, toggle } = useThemeStore()
+  const { theme, toggle } = useThemeStore();
 
   return (
     <div
       style={{
-        fontFamily: 'sans-serif',
-        background: theme === 'light' ? '#fff' : '#202124',
-        color: theme === 'light' ? '#202124' : '#fff',
-        minHeight: '100vh',
+        fontFamily: "sans-serif",
+        background: theme === "light" ? "#fff" : "#202124",
+        color: theme === "light" ? "#202124" : "#fff",
+        minHeight: "100vh",
       }}
     >
       <header
         style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
           padding: 16,
-          background: '#4285F4',
-          color: '#fff',
+          background: "#4285F4",
+          color: "#fff",
         }}
       >
-        <nav style={{ display: 'flex', gap: 16 }}>
+        <nav style={{ display: "flex", gap: 16 }}>
           {/* React Router links */}
-          <Link to="/" style={{ color: '#fff', textDecoration: 'none' }}>
+          <Link to="/" style={{ color: "#fff", textDecoration: "none" }}>
             Products
           </Link>
-          <Link to="/cart" style={{ color: '#fff', textDecoration: 'none' }}>
+          <Link to="/cart" style={{ color: "#fff", textDecoration: "none" }}>
             Cart
           </Link>
         </nav>
         {/* Using Zustand global state */}
-        <Button onClick={toggle} style={{ background: '#0F9D58' }}>
-          Toggle {theme === 'light' ? 'Dark' : 'Light'}
+        <Button onClick={toggle} style={{ background: "#0F9D58" }}>
+          Toggle {theme === "light" ? "Dark" : "Light"}
         </Button>
       </header>
       <main style={{ padding: 16 }}>
@@ -52,5 +53,5 @@ export default function App() {
         </Routes>
       </main>
     </div>
-  )
+  );
 }

--- a/my-app/src/components/atoms/Button.jsx
+++ b/my-app/src/components/atoms/Button.jsx
@@ -1,0 +1,24 @@
+/**
+ * Atom: Button
+ * -------------
+ * Atoms are the smallest building blocks.
+ * This button shows prop usage and event handling.
+ */
+export default function Button({ children, onClick, style = {} }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        padding: '8px 16px',
+        border: 'none',
+        borderRadius: 4,
+        cursor: 'pointer',
+        background: '#4285F4',
+        color: '#fff',
+        ...style,
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/my-app/src/components/molecules/ProductCard.jsx
+++ b/my-app/src/components/molecules/ProductCard.jsx
@@ -1,0 +1,24 @@
+import Button from '../atoms/Button'
+
+/**
+ * Molecule: ProductCard
+ * ---------------------
+ * Combines atoms to display a product.
+ * Demonstrates prop drilling and events.
+ */
+export default function ProductCard({ product, onAdd }) {
+  return (
+    <div
+      style={{
+        border: '1px solid #ccc',
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+      }}
+    >
+      <h3>{product.title}</h3>
+      {/* Returning events to parent via props */}
+      <Button onClick={() => onAdd(product)}>Add to Cart</Button>
+    </div>
+  )
+}

--- a/my-app/src/components/organisms/ProductList.jsx
+++ b/my-app/src/components/organisms/ProductList.jsx
@@ -1,0 +1,17 @@
+import ProductCard from '../molecules/ProductCard'
+
+/**
+ * Organism: ProductList
+ * ---------------------
+ * Larger structures composed of molecules.
+ * Receives data via props (prop drilling example).
+ */
+export default function ProductList({ products, onAdd }) {
+  return (
+    <div>
+      {products.map((p) => (
+        <ProductCard key={p.id} product={p} onAdd={onAdd} />
+      ))}
+    </div>
+  )
+}

--- a/my-app/src/context/CartContext.jsx
+++ b/my-app/src/context/CartContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState } from 'react'
+
+/**
+ * CartContext
+ * ------------
+ * Using the Context API to expose cart state across the app.
+ * Demonstrates global state without a third‑party library.
+ *
+ * Concepts: Context, useState, custom hooks.
+ */
+const CartContext = createContext()
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useCart = () => useContext(CartContext)
+
+export function CartProvider({ children }) {
+  // Local state inside provider becomes global to all descendants
+  const [items, setItems] = useState([])
+
+  // Add product to cart
+  const addToCart = (product) => setItems((prev) => [...prev, product])
+
+  // Remove product
+  const removeFromCart = (id) => setItems((prev) => prev.filter((p) => p.id !== id))
+
+  return (
+    <CartContext.Provider value={{ items, addToCart, removeFromCart }}>
+      {children}
+    </CartContext.Provider>
+  )
+}

--- a/my-app/src/index.css
+++ b/my-app/src/index.css
@@ -1,68 +1,9 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+/* Global styles mimicking Google's clean theme */
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  color: inherit;
 }

--- a/my-app/src/main.jsx
+++ b/my-app/src/main.jsx
@@ -1,20 +1,22 @@
 /**
  * Entry point for the React application.
- * React keeps a lightweight representation of the DOM in memory (the virtual DOM).
- * When components update, React compares this virtual DOM with the real DOM and
- * efficiently updates only what changed.
+ * Demonstrates Context and React Router setup.
  */
-
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import { CartProvider } from './context/CartContext'
 
-// Attach the component tree to the real DOM element with id 'root'
 createRoot(document.getElementById('root')).render(
-  // StrictMode helps highlight potential problems in an application
   <StrictMode>
-    {/* App is the root LEGO block of our interface */}
-    <App />
+    {/* BrowserRouter enables client-side routing */}
+    <BrowserRouter>
+      {/* CartProvider exposes global cart state */}
+      <CartProvider>
+        <App />
+      </CartProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/my-app/src/pages/CartPage.jsx
+++ b/my-app/src/pages/CartPage.jsx
@@ -1,0 +1,26 @@
+import { useCart } from '../context/CartContext'
+import Button from '../components/atoms/Button'
+
+/**
+ * Page: Cart
+ * -----------
+ * Reads global state from Context and renders items.
+ */
+export default function CartPage() {
+  const { items, removeFromCart } = useCart()
+
+  return (
+    <div>
+      <h2>Cart</h2>
+      {items.length === 0 && <p>No items yet.</p>}
+      {items.map((item) => (
+        <div key={item.id} style={{ marginBottom: 8 }}>
+          {item.title}{' '}
+          <Button style={{ background: '#DB4437' }} onClick={() => removeFromCart(item.id)}>
+            Remove
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/my-app/src/pages/ProductsPage.jsx
+++ b/my-app/src/pages/ProductsPage.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+import ProductList from '../components/organisms/ProductList'
+import { useCart } from '../context/CartContext'
+
+/**
+ * Page: Products
+ * --------------
+ * Demonstrates routing, fetching data with useEffect and
+ * passing props down the component tree.
+ */
+export default function ProductsPage() {
+  const { addToCart } = useCart() // accessing context
+
+  // Local component state
+  const [products, setProducts] = useState([])
+
+  // useEffect for side effects (API call)
+  useEffect(() => {
+    fetch('https://fakestoreapi.com/products?limit=5')
+      .then((res) => res.json())
+      .then(setProducts)
+  }, [])
+
+  return (
+    <div>
+      <h2>Products</h2>
+      <ProductList products={products} onAdd={addToCart} />
+    </div>
+  )
+}

--- a/my-app/src/store/useThemeStore.js
+++ b/my-app/src/store/useThemeStore.js
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+/**
+ * useThemeStore (Zustand example)
+ * -------------------------------
+ * Zustand provides a lightweight global store without Context.
+ * Here we track UI theme to show alternative global state management.
+ */
+export const useThemeStore = create((set) => ({
+  theme: 'light',
+  toggle: () =>
+    set((state) => ({ theme: state.theme === 'light' ? 'dark' : 'light' })),
+}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "React-Complete-Tutorial",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Summary
- add products and cart pages wired with React Router
- share cart state via Context API and theme via Zustand store
- demonstrate atomic design components and Google-inspired styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae287cf22c83218c6279a1966608c5